### PR TITLE
Temporarily disable Adaptarr on Safair, Edge and IE

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,15 +20,46 @@ if (SENTRY_DSN) {
   })
 }
 
-ReactDOM.render(
-  <Provider store={store}>
-    <LocalizationProvider>
-      <ErrorBoundary>
-        <App />
-      </ErrorBoundary>
-    </LocalizationProvider>
-  </Provider>,
-  document.getElementById('root') as HTMLElement
-)
+// Temporarily disable Adaptarr on Safari, Edge and Internet Explorer due to:
+// https://github.com/openstax-poland/adaptarr-front/issues/197
+// eslint-disable-next-line spaced-comment
+const isIE = /*@cc_on!@*/false || Boolean((document as any).documentMode)
+const isEdge = /Edge/.test(navigator.userAgent)
+const isSafari = (window as any).safari !== undefined
+if (isSafari || isEdge || isIE) {
+  ReactDOM.render(
+    <BrowsersNotSupported />,
+    document.getElementById('root') as HTMLElement
+  )
+} else {
+  ReactDOM.render(
+    <Provider store={store}>
+      <LocalizationProvider>
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
+      </LocalizationProvider>
+    </Provider>,
+    document.getElementById('root') as HTMLElement
+  )
+}
 
 unregister()
+
+function BrowsersNotSupported() {
+  const style: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+    fontSize: '20px',
+    fontWeight: 700,
+  }
+
+  return (
+    <div style={style}>
+      We currently provide full support only for Firefox and Chrome browsers.
+    </div>
+  )
+}


### PR DESCRIPTION
Temporarily disable Adaptarr on Safair, Edge and IE until we fix issues related to: #197 

![obraz](https://user-images.githubusercontent.com/31478212/67482779-9fd1cc80-f664-11e9-9ce1-67f1ab8e1e4b.png)
