### PR TITLE
Fixes for UserProfile component

### DIFF
--- a/public/locale/en/ui.ftl
+++ b/public/locale/en/ui.ftl
@@ -271,7 +271,7 @@ dashboard-drafts-view = View draft
 
 dashboard-drafts-delete = Delete
 
-dashboard-drafts-empty = You don't have any drafts
+dashboard-drafts-empty = There are no drafts to display
 
 dashboard-drafts-details = Details
 

--- a/src/components/DraftsList/index.tsx
+++ b/src/components/DraftsList/index.tsx
@@ -210,7 +210,7 @@ class DraftsList extends React.Component<DraftsListProps> {
               </ul>
               :
               <Localized id="dashboard-drafts-empty">
-                You do not have any drafts.
+                There are no drafts to display
               </Localized>
         }
       </div>

--- a/src/containers/UserProfile/ProfileRoles/index.tsx
+++ b/src/containers/UserProfile/ProfileRoles/index.tsx
@@ -88,6 +88,10 @@ const ProfileRoles = (props: ProfileRolesProps) => {
       })
   }
 
+  React.useEffect(() => {
+    setUserTeams(props.user.teams)
+  }, [props.user.id])
+
   const { loggedUser, teams } = props
 
   return (

--- a/src/containers/UserProfile/index.tsx
+++ b/src/containers/UserProfile/index.tsx
@@ -65,7 +65,10 @@ const UserProfile = (props: UserProfileProps) => {
 
   React.useEffect(() => {
     setUserName(props.user.name)
-    if (props.loggedUser.allPermissions.has('editing-process:manage')) {
+    if (
+      props.loggedUser.is_super
+      || props.loggedUser.allPermissions.has('editing-process:manage')
+    ) {
       fetchUsersDrafts()
     }
   }, [props.user.id])


### PR DESCRIPTION
close #203 

- [x] Fix for roles names which were not update when switching between user profiles.
- [x] When there was no users drafts to display text in english was incorrectly suggesting that it's about currently logged users drafts. Change from: `You don't have any drafts` to `There are no drafts to display`
- [x] There was bug when users with `is_super` flag but without `editing-process:manage` permission were not fetching users drafts.