### PR TITLE
Move logout button to bottom of navigation

### DIFF
--- a/src/components/Navigation/index.css
+++ b/src/components/Navigation/index.css
@@ -91,6 +91,7 @@
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
+  margin-top: 10px;
 }
 
 .nav ul {

--- a/src/components/Navigation/index.css
+++ b/src/components/Navigation/index.css
@@ -1,4 +1,6 @@
 .sidebar {
+  display: flex;
+  flex-direction: column;
   width: 250px;
   border-right: 1px solid #fff;
 }
@@ -82,6 +84,17 @@
 .menu-toggler .button .icon {
   fill: var(--dark-bg);
   padding-right: 20px;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.nav ul {
+  width: 100%;
 }
 
 .nav__link {

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -203,14 +203,6 @@ class Navigation extends React.Component<RouteComponentProps & NavigationProps> 
                     Settings
                   </Localized>
                 </NavLink>
-                <a
-                  className="nav__link"
-                  href="/logout"
-                >
-                  <Localized id="navigation-logout">
-                    Logout
-                  </Localized>
-                </a>
               </div>
             </li>
             <li className="nav__link">
@@ -280,6 +272,18 @@ class Navigation extends React.Component<RouteComponentProps & NavigationProps> 
               </li>
             </LimitedUI>
           </ul>
+          <div className="nav__link">
+            <a href="/logout">
+              <span className="nav__content">
+                <Icon size="medium" name="logout" />
+                <span className="nav__text">
+                  <Localized id="navigation-logout">
+                    Logout
+                  </Localized>
+                </span>
+              </span>
+            </a>
+          </div>
         </nav>
       </aside>
     )


### PR DESCRIPTION
close #207 

Move logout button to the bottom of navigation:
![obraz](https://user-images.githubusercontent.com/31478212/67952773-1f741400-fbee-11e9-8351-4f0e82479c16.png)

This should also work with small menu: 
![obraz](https://user-images.githubusercontent.com/31478212/67952831-3c104c00-fbee-11e9-953c-21c48906c0f1.png)
