### PR TITLE
Better validation for urls

### DIFF
--- a/src/containers/Chat/components/InputEditor/index.tsx
+++ b/src/containers/Chat/components/InputEditor/index.tsx
@@ -13,7 +13,7 @@ import { Localized } from 'fluent-react/compat'
 
 import { Conversation, User } from 'src/api'
 
-import { VALID_URL_PATTERN } from 'src/helpers/isValidUrl'
+import { isValidUrl } from 'src/helpers'
 
 import SCHEMA from './schema'
 import serialize from './serialize'
@@ -82,7 +82,7 @@ class InputEditor extends React.Component<InputEditorProps> {
       let offset = 0
 
       for (const str of splitted) {
-        if (VALID_URL_PATTERN.test(str)) {
+        if (isValidUrl(str)) {
           const startOffset = offset
 
           // Unshift because we want to convert texts from end to start since

--- a/src/containers/Chat/components/InputEditor/schema.ts
+++ b/src/containers/Chat/components/InputEditor/schema.ts
@@ -1,6 +1,6 @@
 import { Block, Editor, Inline, SlateError } from 'slate'
 
-import { VALID_URL_PATTERN } from 'src/helpers/isValidUrl'
+import { isValidUrl } from 'src/helpers'
 
 import { CONTEXT_ANNOTATION_TYPE } from '../InputEditor'
 
@@ -48,7 +48,7 @@ export default {
   inlines: {
     hyperlink: {
       data: {
-        url: (u: any) => VALID_URL_PATTERN.test(u),
+        url: (u: any) => isValidUrl(u),
       },
       normalize: normalizeHyperLink,
     },

--- a/src/containers/Chat/components/Message/index.tsx
+++ b/src/containers/Chat/components/Message/index.tsx
@@ -153,7 +153,7 @@ function Line({ data }: { data: Data }): JSX.Element[] {
       const [len, inx] = leb128(body, 0)
       const label = decode_utf8(body.subarray(inx, inx + len))
       let url = String.fromCodePoint.apply(null, body.subarray(inx + len))
-      if (!url.match(/https?:\/\//)) {
+      if (/^www\./.test(url)) {
         url = 'http://' + url
       }
 

--- a/src/helpers/isValidUrl.ts
+++ b/src/helpers/isValidUrl.ts
@@ -1,13 +1,14 @@
-export const VALID_URL_PATTERN = new RegExp('^(https?:\\/\\/)?'+ // protocol
-'((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
-'((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
-'(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
-'(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
-'(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-
 const isValidUrl = (url: string) => {
-  const isValid = Boolean(VALID_URL_PATTERN.test(url))
-  return isValid
+  if (/^www\./.test(url)) {
+    url = 'http://' + url
+  }
+
+  try {
+    const _ = new URL(url)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export default isValidUrl


### PR DESCRIPTION
I've changed regexp test to [new URL()](https://developer.mozilla.org/en-US/docs/Web/API/URL)
I've extended it to one more case, when link starts with `www.`