### PR TITLE
Show draft files

### DIFF
--- a/public/locale/en/ui.ftl
+++ b/public/locale/en/ui.ftl
@@ -1137,6 +1137,12 @@ draft-info-permission = { $permission ->
 
 
 
+## Reusable components - draft files
+
+draft-files-title = Files associated with this draft:
+
+
+
 ## Reusable components - free slots
 
 free-slots-not-assigned = Not assigned to any book

--- a/public/locale/pl/ui.ftl
+++ b/public/locale/pl/ui.ftl
@@ -1127,6 +1127,12 @@ draft-info-permission = { $permission ->
 
 
 
+## Reusable components - draft files
+
+draft-files-title = Pliki powiązane z tym szkicem:
+
+
+
 ## Reusable components - free slots
 
 free-slots-not-assigned = Nie przypisano do żadnej książki

--- a/src/api/draft.ts
+++ b/src/api/draft.ts
@@ -24,6 +24,11 @@ export type DraftData = {
   team: TeamID
 }
 
+export type DraftFile = {
+  name: string
+  mime: string
+}
+
 /**
  * Result data for POST /api/v1/drafts/:id/advance
  */
@@ -144,7 +149,7 @@ export default class Draft extends Base<DraftData> {
   /**
    * Fetch list of files in this draft. This list does not include index.cnxml.
    */
-  async files(): Promise<string[]> {
+  async files(): Promise<DraftFile[]> {
     return (await axios.get(`drafts/${this.module}/files`)).data
   }
 

--- a/src/components/DraftFiles/index.css
+++ b/src/components/DraftFiles/index.css
@@ -1,0 +1,33 @@
+.draft-files__title {
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  height: 46px;
+  background-color: var(--light-bg);
+}
+
+.draft-files__list {
+  background-color: #fff;
+}
+
+.draft-files__link {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 20px;
+  color: var(--font-dark);
+}
+
+.draft-files__link:hover {
+  color: var(--font-light);
+  background-color: var(--dark-bg);
+}
+
+.draft-files__thumb {
+  min-width: auto;
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+  margin-right: 10px;
+}

--- a/src/components/DraftFiles/index.tsx
+++ b/src/components/DraftFiles/index.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react'
+import { Localized } from 'fluent-react/compat'
+
+import Draft, { DraftFile } from 'src/api/draft'
+
+import Spinner from 'src/components/Spinner'
+
+import './index.css'
+
+interface DraftFilesProps {
+  draft: Draft
+}
+
+const DraftFiles = ({ draft }: DraftFilesProps) => {
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [files, setFiles] = React.useState<DraftFile[]>([])
+
+  const fetchFiles = async () => {
+    const fls = await draft.files()
+    setFiles(fls)
+    setIsLoading(false)
+  }
+
+  React.useEffect(() => {
+    fetchFiles()
+  }, [])
+
+  if (isLoading) return <Spinner />
+
+  return (
+    <div className="draft-files">
+      <h3 className="draft-files__title">
+        <Localized id="draft-files-title">
+          Files associated with this draft:
+        </Localized>
+      </h3>
+      <ul className="draft-files__list">
+        {
+          files.map(file => (
+            <DraftFilePresentation
+              key={file.name}
+              draftId={draft.module}
+              file={file}
+            />
+          ))
+        }
+      </ul>
+    </div>
+  )
+}
+
+export default DraftFiles
+
+interface DraftFilePresentationProps {
+  draftId: string
+  file: DraftFile
+}
+
+const DraftFilePresentation = ({ draftId, file }: DraftFilePresentationProps) => {
+  const url = `/api/v1/drafts/${draftId}/files/${file.name}`
+
+  return (
+    <li className="draft-files__file">
+      <a
+        className="draft-files__link"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {
+          /^image/.test(file.mime)
+            ? <img className="draft-files__thumb" src={url}/>
+            : null
+        }
+        {file.name}
+      </a>
+    </li>
+  )
+}

--- a/src/screens/app/DraftDetails/index.css
+++ b/src/screens/app/DraftDetails/index.css
@@ -8,3 +8,8 @@
 .draft-details .section__content .button {
   margin-right: 20px;
 }
+
+.draft-details .draft-files {
+  margin: 20px 0;
+  max-width: 800px;
+}

--- a/src/screens/app/DraftDetails/index.tsx
+++ b/src/screens/app/DraftDetails/index.tsx
@@ -15,6 +15,7 @@ import Header from 'src/components/Header'
 import Section from 'src/components/Section'
 import Spinner from 'src/components/Spinner'
 import DraftInfo from 'src/components/DraftInfo'
+import DraftFiles from 'src/components/DraftFiles'
 import Button from 'src/components/ui/Button'
 import Dialog from 'src/components/ui/Dialog'
 
@@ -133,6 +134,7 @@ class DraftDetais extends React.Component<DraftDetailsProps> {
             }
           </Button>
         </div>
+        <DraftFiles draft={draft} />
         {
           showImportDialog ?
             <Dialog


### PR DESCRIPTION
Display draft files on draft details screen.
If file is an image thumbnail should be displayed.
Clicking on file will open this file in new window.

![obraz](https://user-images.githubusercontent.com/31478212/68319683-ff959200-00be-11ea-9644-8eb5f8aa234d.png)